### PR TITLE
Fixes random task generator choosing already completed/ignored tasks

### DIFF
--- a/src/components/TaskGenerator.js
+++ b/src/components/TaskGenerator.js
@@ -26,7 +26,7 @@ export default function TaskGenerator() {
     const generateTask = () => {
         const notPossibleTaskIDsFromStore = Object.entries(reduxTasks)
             .filter(([, { completed, ignored }]) => completed || ignored)
-            .map(([taskId]) => +taskId);
+            .map(([taskId]) => taskId);
 
         const possibleTasks = allTasks.filter(task => !notPossibleTaskIDsFromStore.includes(task.id));
         const randomTask = possibleTasks[Math.floor(Math.random() * possibleTasks.length)];


### PR DESCRIPTION
This fixes the random task generator, originally tasks were being converted into to numbers and then being compared to strings.

Just changed it so that it is a string to string comparison.