### PR TITLE
Fix: Region section in both character and tasks panel to handle all unlocks

### DIFF
--- a/src/components/CharacterRegionsSection.js
+++ b/src/components/CharacterRegionsSection.js
@@ -56,7 +56,8 @@ export default function CharacterRegionsSection({ unlockedRegions, taskStats }) 
           <div className='flex w-full flex-wrap justify-around text-center align-middle tracking-wide text-md text-primary gap-3'>
             <span>{`Regions unlocked: ${unlockedRegions.filter(id => id !== NONE_REGION_ID).length} / 5`}</span>
             <span>
-              {unlockedRegions.filter(region => region >= 0).length === 5
+              {unlockedRegions.filter(region => region >= 0).length === 5 ||
+              regionTier >= REGION_UNLOCK_THRESHOLDS.length - 1
                 ? 'All regions unlocked!'
                 : `Next unlock at ${nextUnlockThreshold} tasks (${
                     nextUnlockThreshold - taskStats.tasks.complete.total

--- a/src/pages/TasksPanel.js
+++ b/src/pages/TasksPanel.js
@@ -61,7 +61,7 @@ export default function TasksPanel({ readonly, taskState }) {
               />
             </div>
             <div className='text-accent text-sm text-center'>
-              {regionTier <= REGION_UNLOCK_THRESHOLDS.length + 1 ? (
+              {regionTier < REGION_UNLOCK_THRESHOLDS.length - 1 ? (
                 <span>{`Next region unlocked at ${REGION_UNLOCK_THRESHOLDS[regionTier + 1]} tasks (${
                   REGION_UNLOCK_THRESHOLDS[regionTier + 1] - taskStats.tasks.complete.total
                 } remaining)`}</span>


### PR DESCRIPTION
When you have the correct number of tasks completed the tasks panel shows:
![image](https://github.com/user-attachments/assets/13fb4fd3-3600-4f4e-95ea-90bb88ece1d1)

And when you have not selected all of your regions on the character panel it shows:
![image](https://github.com/user-attachments/assets/dcb96629-fd2c-43e6-984f-fcd23d52753a)

Fixed to show the following:
  Tasks panel:
![image](https://github.com/user-attachments/assets/c6af9b01-dcf3-4b24-ad01-73d8288f0eae)

  Character panel:
![image](https://github.com/user-attachments/assets/30bf1260-cc3d-4f69-be19-c26baa8d77dc)
